### PR TITLE
Add get trip types (list) endpoint

### DIFF
--- a/TEQ_Public_API_1.0_modular.yaml
+++ b/TEQ_Public_API_1.0_modular.yaml
@@ -93,6 +93,10 @@ paths:
     $ref: './paths/core-employees.yaml#/~1core~1employees'
   /core/employees/calendar/{id}:
     $ref: './paths/core-employees.yaml#/~1core~1employees~1calendar~1{id}'
+  
+  # Core/Settings
+  /core/settings/triptypes:
+    $ref: './paths/core-settings.yaml#/~1core~1settings~1triptypes'
 
 components:
   responses:    

--- a/components/schemas/TripType.yaml
+++ b/components/schemas/TripType.yaml
@@ -7,14 +7,14 @@ properties:
     type: string
     description: The name of the trip type
     example: Standard
-  description:
-    type: string
-    description: The description of the trip type
-    example: Standard trip type
   category:
     type: string
     description: The category of the trip type
-    example: Normal
+    example: NORMAL
+  description:
+    type: string
+    description: The description of the trip type
+    example: Standard trip type  
   tripPriority:
     type: integer
     description: The trip priority for trips of this type

--- a/paths/core-settings.yaml
+++ b/paths/core-settings.yaml
@@ -1,0 +1,18 @@
+/core/settings/triptypes:
+  get:
+    description: Returns a list of trip types
+    tags:
+      - Core/Settings
+    parameters:
+      - $ref: "../components/parameters/domain.yaml"        
+    responses:
+      "200":
+        description: Successfully returned a list of trip types
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "../components/schemas/TripType.yaml"
+      "400":
+        $ref: "../components/responses/400.yaml"


### PR DESCRIPTION
## Summary
- Added new `GET /core/settings/triptypes` endpoint to list trip types
- Reordered `TripType` schema fields (category before description) and fixed example casing for `category` to `NORMAL`

## Test plan
- [ ] Validate OpenAPI spec (lint/bundle) still resolves correctly
- [ ] Confirm new path renders correctly in docs UI