### PR TITLE
Update PostOrder/PostTrip schemas and sales-orders response

### DIFF
--- a/components/schemas/PostOrder.yaml
+++ b/components/schemas/PostOrder.yaml
@@ -1,4 +1,22 @@
 properties:
+  orderContactPersonId:
+    type: integer
+    description: The ID of the contact person for the order
+    example: 2255
+  newOrderContactPerson:
+    $ref: "./NewContactPerson.yaml"
+  salesPersonId:
+    type: integer
+    description: The ID of the sales person for the order
+    example: 100
+  externalOrderReference:
+    type: string
+    description: The external order reference
+    example: "EXT-12345"
+  orderStatus:
+    type: string
+    description: The status of the order
+    example: "draft"
   trips:
     type: array
     items:

--- a/components/schemas/PostOrder.yaml
+++ b/components/schemas/PostOrder.yaml
@@ -15,9 +15,17 @@ properties:
     example: "EXT-12345"
   orderStatus:
     type: string
-    description: The status of the order
-    example: "draft"
+    description: "The status to set for the newly created order"
+    enum:
+      - Draft
+      - Sent to customer
+      - Accepted by customer
+      - Active order
+    default: Active order
   trips:
     type: array
     items:
       $ref: "./PostTrip.yaml"
+
+
+

--- a/components/schemas/PostTrip.yaml
+++ b/components/schemas/PostTrip.yaml
@@ -51,9 +51,7 @@ properties:
     type: string
     description: The group reference for the trip, this field is only relevant when the tripTypeId is set to the type Airport Trip  
   acceptTerms:
-    type: boolean
-  externalReference:
-    type: string
+    type: boolean  
   vehicleLicensePlate:
     type: string
     description: "The license plate of the vehicle to use for the trip, only relevant if a specific vehicle is requested"

--- a/components/schemas/PostTrip.yaml
+++ b/components/schemas/PostTrip.yaml
@@ -111,12 +111,3 @@ properties:
       end:
         type: string
         format: date-time
-  orderStatus:
-    type: string
-    description: "The status to set for the newly created order"
-    enum:
-      - Draft
-      - Sent to customer
-      - Accepted by customer
-      - Active order
-    default: Active order

--- a/paths/sales-orders.yaml
+++ b/paths/sales-orders.yaml
@@ -34,6 +34,10 @@
             schema:
               type: object
               properties:
+                status:
+                  type: string
+                  description: "The status of the operation"
+                  example: "success"
                 orderId:
                   type: string
                   description: "The unique internal order ID created"
@@ -42,6 +46,10 @@
                   type: string
                   description: "The order ID in the format used in TEQ UI, e.g. BT-034150-S01"
                   example: "BT-034150-S01"
+                createdRows:
+                  type: integer
+                  description: "The number of rows created"
+                  example: 1
       "400":
         $ref: "../components/responses/400.yaml"
       "404":


### PR DESCRIPTION
## Summary
- Move `orderStatus` from `PostTrip` to `PostOrder` (order-level, not trip-level)
- Remove `externalReference` from `PostTrip`
- Add `orderContactPersonId`, `newOrderContactPerson`, `salesPersonId`, `externalOrderReference`, and `orderStatus` to `PostOrder`
- Add `status` and `createdRows` fields to the sales-orders 201 response

## Test plan
- [ ] Validate OpenAPI spec lints/builds correctly
- [ ] Confirm schema changes match the actual API response shape