### PR TITLE
PROD-4969: add boarding and disembarkation fields to trip payload

### DIFF
--- a/TEQ_Public_API_1.0_modular.yaml
+++ b/TEQ_Public_API_1.0_modular.yaml
@@ -128,7 +128,9 @@ components:
     PutCustomer:
       $ref: './components/schemas/PutCustomer.yaml'
     CustomerFixedTripInfo:
-      $ref: './components/schemas/CustomerFixedTripInfo.yaml'
+      $ref: './components/schemas/CustomerFixedTripInfo.yaml' 
+    CustomerList:
+      $ref: './components/schemas/CustomerList.yaml'      
     
     # Trip related schemas
     GeoLocation:

--- a/components/schemas/CustomerList.yaml
+++ b/components/schemas/CustomerList.yaml
@@ -1,0 +1,17 @@
+properties:
+  count:
+    type: integer
+    description: Total number of results
+    example: 552
+  next:
+    type: string
+    description: URL to get next page of results
+    example: "http://api.ferdia.app/publicapi/sales/customers?page=3"
+  previous:
+    type: string
+    description: URL to get previous page of results
+    example: "http://api.ferdia.app/publicapi/sales/customers?page=1"
+  results:
+    type: array
+    items:
+      $ref: "./CustomerListEntry.yaml"

--- a/components/schemas/CustomerListEntry.yaml
+++ b/components/schemas/CustomerListEntry.yaml
@@ -1,0 +1,24 @@
+properties:
+  id:
+    type: integer
+  number:
+    type: string
+  name:
+    type: string
+  email:
+    type: string
+    format: email
+  type:
+    $ref: "./CustomerType.yaml"
+  orgno:
+    type: string
+  category:
+    $ref: "./CustomerCategory.yaml"
+  addresses:
+    type: array
+    items:
+      $ref: "./Address.yaml"
+  contactPersons:
+    type: array
+    items:
+      $ref: "./ContactPerson.yaml"

--- a/components/schemas/PostTrip.yaml
+++ b/components/schemas/PostTrip.yaml
@@ -25,6 +25,14 @@ properties:
   returnTime:
     type: string
     pattern: '^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$'
+  boarding:
+    type: integer
+    description: "Number of minutes for boarding the passengers"
+    example: 10
+  disembarkation:
+    type: integer
+    description: "Number of minutes for disembarking the passengers"
+    example: 15
   travelFrom:
     $ref: "./Location.yaml"
   travelTo:

--- a/paths/sales-customers.yaml
+++ b/paths/sales-customers.yaml
@@ -64,10 +64,8 @@
         description: Successfully returned a list of customers
         content:
           application/json:
-            schema:
-              type: array
-              items:
-                $ref: "../components/schemas/Customer.yaml"
+            schema:           
+              $ref: "../components/schemas/CustomerList.yaml"
       "400":
         $ref: "../components/responses/400.yaml"
       


### PR DESCRIPTION
Closes PROD-4969

## Changes
- Added `boarding` (integer) field to the trip payload schema — number of minutes for boarding passengers, example `10`
- Added `disembarkation` (integer) field to the trip payload schema — number of minutes for disembarking passengers, example `15`
- Both fields placed before `travelFrom` in `components/schemas/PostTrip.yaml`, used by `POST /sales/orders/{customerId}`

## Notes
- Neither field is required